### PR TITLE
added the paid_at field

### DIFF
--- a/getmyinvoices/client.py
+++ b/getmyinvoices/client.py
@@ -88,6 +88,7 @@ class GMI:
                             document_due_date=None,
                             payment_method=None,
                             payment_status=None,
+                            paid_at=None,
                             net_amount=None,
                             gross_amount=None,
                             currency=None,
@@ -109,6 +110,7 @@ class GMI:
         self._optional(payload, "document_date", document_date)
         self._optional(payload, "payment_method", payment_method)
         self._optional(payload, "payment_status", payment_status)
+        self._optional(payload, "paid_at", paid_at)
         self._optional(payload, "gross_amount", gross_amount)
         self._optional(payload, "net_amount", net_amount)
         self._optional(payload, "currency", currency)
@@ -133,6 +135,7 @@ class GMI:
                         document_due_date=None,
                         payment_method=None,
                         payment_status=None,
+                        paid_at=None,
                         net_amount=None,
                         gross_amount=None,
                         currency=None,
@@ -152,6 +155,7 @@ class GMI:
         self._optional(payload, "document_due_date", document_due_date)
         self._optional(payload, "payment_method", payment_method)
         self._optional(payload, "payment_status", payment_status)
+        self._optional(payload, "paid_at", paid_at)
         self._optional(payload, "net_amount", net_amount)
         self._optional(payload, "gross_amount", gross_amount)
         self._optional(payload, "vat", vat)

--- a/getmyinvoices/client.py
+++ b/getmyinvoices/client.py
@@ -170,6 +170,11 @@ class GMI:
         response = self._post(payload, "/updateDocument")
         return json.loads(response.data)
 
+    def delete_document(self, document_prim_uid):
+        payload = {"document_prim_uid": document_prim_uid}
+        response = self._post(payload, "/deleteDocument")
+        return json.loads(response.data)
+
     def get_countries(self):
         response = self._post({}, "/getCountries")
         return json.loads(response.data)


### PR DESCRIPTION
This adds the paid_at field.

From the getmyinvoice documentation:

> paid_at | stringPaid at date (format: Y-m-d), When payment_status = 'Paid'

This was mandatory for the v2 endpoint. Getmyinvoices support patched it. But it's still nice to have.

